### PR TITLE
Updated fixtures to include a card with a nickname

### DIFF
--- a/lib/tfl/client.rb
+++ b/lib/tfl/client.rb
@@ -46,7 +46,13 @@ module TFL
         card = TFL::Card.new
         card.id            = c.attributes['href'].value.to_s[/\/Card\/View\?pi=(.*)/,1]
         card.network       = c.css('h3.current-nickname span.sr-only').text.to_s[/(MasterCard|Visa)/]
-        card.last_4_digits = c.css('span.view-card-nickname').text.to_s[/\d{4}/]
+
+        card.last_4_digits = if c.css('span[data-pageobject="view-card-last4digits"]').empty? then
+          c.css('span.view-card-nickname').text.to_s[/\d{4}/]
+        else
+          c.css('span[data-pageobject="view-card-last4digits"]').text
+        end
+
         card.expiry        = c.css('span[data-pageobject=view-card-cardexpiry]').text.to_s.strip
         @cards << card unless @cards.find{|c| c.id == card.id}
       end

--- a/spec/fixtures/my_cards.html
+++ b/spec/fixtures/my_cards.html
@@ -327,7 +327,7 @@
                     <img src="/Content/casc/images/blank.gif" alt="" class="image-cards-visa-medium pull-left hidden-xs hidden-sm" aria-hidden="true" data-pageobject="view-card-logo">
                     <h3 class="current-nickname">
                         <span class="sr-only">Visa card number:</span>
-                        <span class="view-card-nickname">ending in 5678</span>
+                        <span class="view-card-nickname">Cardy McCardface</span>
                     </h3>
                 </div>
                 <div class="col-xs-12 col-sm-5">
@@ -343,6 +343,7 @@
                             <p>&nbsp;</p>
                         </div>
                         <div class="col-md-7 col-lg-8 ticket-details">
+                            <p>Card number: ending in <span data-pageobject="view-card-last4digits">5678</span></p>
                             <p>
                                 <span class="font-ticket" aria-hidden="true">Card Expires:</span>
                                 <span class="expires" data-pageobject="view-card-cardexpiry">


### PR DESCRIPTION
If a user gives their card a nickname on the TFL website then the last four digits are displayed in a different HTML element.